### PR TITLE
Use foreachE to avoid stack overflow for large graphs

### DIFF
--- a/src/Data/Graph.purs
+++ b/src/Data/Graph.purs
@@ -13,14 +13,12 @@ module Data.Graph
 
 import Prelude hiding
 
-import Control.Monad.Eff (runPure)
+import Control.Monad.Eff (runPure, foreachE)
 import Control.Monad.ST (writeSTRef, modifySTRef, readSTRef, newSTRef, runST)
-
 import Data.Foldable (any, for_, elem)
-import Data.List (List(..), concatMap, reverse, singleton)
+import Data.List (List(..), concatMap, reverse, singleton, toUnfoldable)
 import Data.Map as M
 import Data.Maybe (Maybe(..), isNothing)
-import Data.Traversable (for)
 
 -- | An directed edge between vertices labelled with keys of type `k`.
 data Edge k = Edge k k
@@ -97,7 +95,7 @@ scc' makeKey makeVert (Graph vs es) = runPure (runST (do
       writeSTRef index $ i + one
       modifySTRef path $ Cons v
 
-      for es $ \(Edge k' l) -> when (k == k') $ do
+      foreachE (toUnfoldable es) $ \(Edge k' l) -> when (k == k') $ do
         wIndex <- indexOfKey l
         currentPath <- readSTRef path
 


### PR DESCRIPTION
This lets us compute with larger graphs without stack overflow. Here is a nice benchmark:

``` purescript
topSort (Graph (range 1 2000) (map (\x -> Edge x (x * 2)) (range 2 2000)))
```

This takes about 5-6s on my Mac. I'm guessing it's dominated by the calls to `Data.Map` but it would be interesting to try to profile it.

I think we can do a _lot_ to speed this library up, but for now it seems like few people are using it anyway, and not on large graphs.
