### PR TITLE
update pulp dep to 11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^10.0.4",
-    "purescript-psa": "^0.5.0-rc.1",
+    "pulp": "^11.0.0",
+    "purescript-psa": "^0.5.1",
     "rimraf": "^2.6.1"
   }
 }


### PR DESCRIPTION
When I cloned the repo, ran `npm install && bower install && npm run build` I received an error that `psc` could not be found. Updated the `pulp` dep to `^11.0.0`, ran the same commands and everything built as expected. Also ran tests just to make sure and everything looked good.