### PR TITLE
Add a function to return the list of edges in a graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added an `edges` function that returns a list of all edges in the graph (#17 by @MaybeJustJames)
 - Added `toMap` to unwrap `Graph` (#18)
 
 Bugfixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `toMap` to unwrap `Graph` (#18)
 
 Bugfixes:
 
@@ -19,7 +20,6 @@ Breaking changes:
 
 New features:
 - Added `Foldable` and `Traversable` instances for `Graph` (#16 by @MaybeJustJames)
-- Added `toMap` to unwrap `Graph` (#18)
 
 Bugfixes:
 

--- a/bower.json
+++ b/bower.json
@@ -20,8 +20,7 @@
   ],
   "dependencies": {
     "purescript-catenable-lists": "^7.0.0",
-    "purescript-ordered-collections": "^3.0.0",
-    "purescript-tailrec": "^6.0.0"
+    "purescript-ordered-collections": "^3.0.0"
   },
   "devDependencies": {
     "purescript-console": "^6.0.0"

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
   ],
   "dependencies": {
     "purescript-catenable-lists": "^7.0.0",
-    "purescript-ordered-collections": "^3.0.0"
+    "purescript-ordered-collections": "^3.0.0",
+    "purescript-tailrec": "^6.0.0"
   },
   "devDependencies": {
     "purescript-console": "^6.0.0"

--- a/src/Data/Graph.purs
+++ b/src/Data/Graph.purs
@@ -2,7 +2,7 @@
 
 module Data.Graph
   ( Graph
-  , Edge(Edge)
+  , Edge(..)
   , unfoldGraph
   , fromMap
   , toMap

--- a/src/Data/Graph.purs
+++ b/src/Data/Graph.purs
@@ -2,7 +2,8 @@
 
 module Data.Graph
   ( Graph
-  , Edge(..)
+  , Destination(..)
+  , Source(..)
   , unfoldGraph
   , fromMap
   , toMap
@@ -46,8 +47,13 @@ instance traversableGraph :: Traversable (Graph k) where
   traverse f (Graph m) = Graph <$> (traverse (\(v /\ ks) -> (_ /\ ks) <$> (f v)) m)
   sequence = traverse identity
 
--- | An edge within a `Graph` referencing endpoint keys
-newtype Edge k = Edge (Tuple k k)
+-- | An edge has a source (a key for a node)
+newtype Source k = Source k
+
+-- | An edge has a destination (a key for a node)
+newtype Destination k = Destination k
+
+type Edge k = Tuple (Source k) (Destination k)
 
 -- | Unfold a `Graph` from a collection of keys and functions which label keys
 -- | and specify out-edges.
@@ -80,7 +86,7 @@ vertices :: forall k v. Graph k v -> List v
 vertices (Graph g) = map fst (M.values g)
 
 -- | List all edges in a graph
-edges :: forall k v. Graph k v -> List (Edge k)
+edges :: forall k v. Graph k v -> List (Tuple (Source k) (Destination k))
 edges (Graph g) = foldlWithIndex edges' Nil g
   where
     edges' :: k -> List (Edge k) -> Tuple v (List k) -> List (Edge k)
@@ -88,7 +94,7 @@ edges (Graph g) = foldlWithIndex edges' Nil g
       foldl (mkEdge src) acc dests
 
     mkEdge :: k -> List (Edge k) -> k -> List (Edge k)
-    mkEdge src acc dest = Edge (src /\ dest) : acc
+    mkEdge src acc dest = (Source src /\ Destination dest) : acc
 
 -- | Lookup a vertex by its key.
 lookup :: forall k v. Ord k => k -> Graph k v -> Maybe v

--- a/src/Data/Graph.purs
+++ b/src/Data/Graph.purs
@@ -2,8 +2,7 @@
 
 module Data.Graph
   ( Graph
-  , Destination(..)
-  , Source(..)
+  , Edge
   , unfoldGraph
   , fromMap
   , toMap
@@ -47,13 +46,8 @@ instance traversableGraph :: Traversable (Graph k) where
   traverse f (Graph m) = Graph <$> (traverse (\(v /\ ks) -> (_ /\ ks) <$> (f v)) m)
   sequence = traverse identity
 
--- | An edge has a source (a key for a node)
-newtype Source k = Source k
-
--- | An edge has a destination (a key for a node)
-newtype Destination k = Destination k
-
-type Edge k = Tuple (Source k) (Destination k)
+-- | An Edge between 2 nodes in a Graph
+type Edge k = { start :: k, end :: k }
 
 -- | Unfold a `Graph` from a collection of keys and functions which label keys
 -- | and specify out-edges.
@@ -86,7 +80,7 @@ vertices :: forall k v. Graph k v -> List v
 vertices (Graph g) = map fst (M.values g)
 
 -- | List all edges in a graph
-edges :: forall k v. Graph k v -> List (Tuple (Source k) (Destination k))
+edges :: forall k v. Graph k v -> List (Edge k)
 edges (Graph g) = foldlWithIndex edges' Nil g
   where
     edges' :: k -> List (Edge k) -> Tuple v (List k) -> List (Edge k)
@@ -94,7 +88,7 @@ edges (Graph g) = foldlWithIndex edges' Nil g
       foldl (mkEdge src) acc dests
 
     mkEdge :: k -> List (Edge k) -> k -> List (Edge k)
-    mkEdge src acc dest = (Source src /\ Destination dest) : acc
+    mkEdge src acc dest = { start: src, end: dest } : acc
 
 -- | Lookup a vertex by its key.
 lookup :: forall k v. Ord k => k -> Graph k v -> Maybe v

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,8 +7,8 @@ import Effect.Console (logShow)
 import Data.Foldable (foldr)
 import Data.Maybe (Maybe(Just))
 import Data.Traversable (traverse)
-import Data.Graph (Graph, unfoldGraph, topologicalSort)
-import Data.List (filter, toUnfoldable, range, (:), List(Nil))
+import Data.Graph (Graph, edges, unfoldGraph, topologicalSort)
+import Data.List (filter, length, toUnfoldable, range, (:), List(Nil))
 
 main :: Effect Unit
 main = do
@@ -20,4 +20,4 @@ main = do
   logShow
     $ filter (_ /= 0) <<< foldr (:) Nil
     <$> traverse (\n -> if n `mod` 2 == 0 then Just 0 else Just n) graph
-
+  logShow (length (edges graph))

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,7 +3,7 @@ module Test.Main where
 import Prelude
 
 import Data.Foldable (foldr)
-import Data.Graph (Graph, Edge(Edge), edges, fromMap, toMap, unfoldGraph, topologicalSort)
+import Data.Graph (Graph, Edge(..), edges, fromMap, unfoldGraph, topologicalSort)
 import Data.List (filter, length, toUnfoldable, range, (:), List(Nil))
 import Data.Map (Map)
 import Data.Map as M

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,22 +2,54 @@ module Test.Main where
 
 import Prelude
 
-import Effect (Effect, foreachE)
-import Effect.Console (logShow)
 import Data.Foldable (foldr)
+import Data.Graph (Graph, Edge(Edge), edges, fromMap, toMap, unfoldGraph, topologicalSort)
+import Data.List (filter, length, toUnfoldable, range, (:), List(Nil))
+import Data.Map (Map)
+import Data.Map as M
 import Data.Maybe (Maybe(Just))
 import Data.Traversable (traverse)
-import Data.Graph (Graph, edges, unfoldGraph, topologicalSort)
-import Data.List (filter, length, toUnfoldable, range, (:), List(Nil))
+import Data.Tuple (Tuple)
+import Data.Tuple.Nested ((/\))
+import Effect (Effect, foreachE)
+import Effect.Console (logShow)
+
+-- An example graph
+--       0
+--      / \
+--     1  2
+--      \/
+--      3
+
+example1 :: Graph Int Int
+example1 =
+  fromMap example1'
+  where
+  example1' :: Map Int (Tuple Int (List Int))
+  example1' =
+    M.fromFoldable
+      [ (0 /\ (0 /\ (1 : 2 : Nil)))
+      , (1 /\ (1 /\ (3 : Nil)))
+      , (2 /\ (2 /\ (3 : Nil)))
+      , (3 /\ (3 /\ Nil))
+      ]
+
+showEdge :: forall k. Show k => Edge k -> String
+showEdge (Edge ends) =
+  show ends
 
 main :: Effect Unit
 main = do
-  let double x | x * 2 < 100000 = [x * 2]
-               | otherwise      = []
-      graph :: Graph Int Int
-      graph = unfoldGraph (range 1 100000) identity double
+  let
+    double x
+      | x * 2 < 100000 = [ x * 2 ]
+      | otherwise = []
+
+    graph :: Graph Int Int
+    graph = unfoldGraph (range 1 100000) identity double
   foreachE (toUnfoldable (topologicalSort graph)) logShow
   logShow
     $ filter (_ /= 0) <<< foldr (:) Nil
-    <$> traverse (\n -> if n `mod` 2 == 0 then Just 0 else Just n) graph
+        <$> traverse (\n -> if n `mod` 2 == 0 then Just 0 else Just n) graph
   logShow (length (edges graph))
+  logShow $ map showEdge $ edges example1

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,7 +3,7 @@ module Test.Main where
 import Prelude
 
 import Data.Foldable (foldr)
-import Data.Graph (Graph, Edge(..), edges, fromMap, unfoldGraph, topologicalSort)
+import Data.Graph (Graph, Source(..), Destination(..), edges, fromMap, unfoldGraph, topologicalSort)
 import Data.List (filter, length, toUnfoldable, range, (:), List(Nil))
 import Data.Map (Map)
 import Data.Map as M
@@ -14,7 +14,7 @@ import Data.Tuple.Nested ((/\))
 import Effect (Effect, foreachE)
 import Effect.Console (logShow)
 
--- An example graph
+-- An example graph:
 --       0
 --      / \
 --     1  2
@@ -34,9 +34,9 @@ example1 =
       , (3 /\ (3 /\ Nil))
       ]
 
-showEdge :: forall k. Show k => Edge k -> String
-showEdge (Edge ends) =
-  show ends
+showEdge :: forall k. Show k => Tuple (Source k) (Destination k) -> String
+showEdge ((Source src) /\ (Destination dest)) =
+  "(" <> show src <> " --> " <> show dest <> ")"
 
 main :: Effect Unit
 main = do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,7 +3,7 @@ module Test.Main where
 import Prelude
 
 import Data.Foldable (foldr)
-import Data.Graph (Graph, Source(..), Destination(..), edges, fromMap, unfoldGraph, topologicalSort)
+import Data.Graph (Graph, Edge, edges, fromMap, unfoldGraph, topologicalSort)
 import Data.List (filter, length, toUnfoldable, range, (:), List(Nil))
 import Data.Map (Map)
 import Data.Map as M
@@ -34,9 +34,9 @@ example1 =
       , (3 /\ (3 /\ Nil))
       ]
 
-showEdge :: forall k. Show k => Tuple (Source k) (Destination k) -> String
-showEdge ((Source src) /\ (Destination dest)) =
-  "(" <> show src <> " --> " <> show dest <> ")"
+showEdge :: forall k. Show k => Edge k -> String
+showEdge { start, end } =
+  "(" <> show start <> " --> " <> show end <> ")"
 
 main :: Effect Unit
 main = do


### PR DESCRIPTION
Adds an `edges` function and a corresponding `Edge` type.

Reasoning for the change:
I had implemented this badly in my own project. `edges` functionality is also necessary to implement an `Eq` instance for `Graph` if that should be considered (RE #1).

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
